### PR TITLE
Fix references to composer package name, dauxio/daux.io -> daux/daux.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Do you use Daux.io? Send me a pull request or open an [issue](https://github.com
 If you have PHP and Composer installed, you can install the dependency
 
 ```bash
-composer global require dauxio/daux.io
+composer global require daux/daux.io
 
 # Next to your `docs` folder, run
 daux generate

--- a/docs/00_Getting_Started.md
+++ b/docs/00_Getting_Started.md
@@ -54,7 +54,7 @@ Do you use Daux.io? Send us a pull request or open an [issue](https://github.com
 If you have PHP and Composer installed, you can install the dependency
 
 ```bash
-composer global require dauxio/daux.io
+composer global require daux/daux.io
 
 # Next to your `docs` folder, run
 daux generate

--- a/docs/_index.md
+++ b/docs/_index.md
@@ -55,7 +55,7 @@
 If you have __PHP__ and Composer installed
 
 ```bash
-composer global require dauxio/daux.io
+composer global require daux/daux.io
 
 # Next to your `docs` folder, run
 daux generate


### PR DESCRIPTION
Corrects composer installation instructions by using correct vendor name.

See issue #3 and #6 