### PR TITLE
Add X-UA-Compatible header for Internet Explorer

### DIFF
--- a/templates/layout/00_layout.php
+++ b/templates/layout/00_layout.php
@@ -10,6 +10,7 @@
     <meta name="description" content="<?= $params['tagline']; ?>" />
     <meta name="author" content="<?= $params['author']; ?>">
     <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <link rel="icon" href="<?= $params['theme']['favicon']; ?>" type="image/x-icon">
     <!-- Mobile -->
     <meta name="apple-mobile-web-app-capable" content="yes" />


### PR DESCRIPTION
The IE opens intranet site often in compatible mode. In this mode looks the DAUX layout not good. With this header we say the IE that he can use the newest browser engine.