### PR TITLE
Add "date_modified_format" option to html export

### DIFF
--- a/docs/05_Configuration/Html_export.md
+++ b/docs/05_Configuration/Html_export.md
@@ -72,11 +72,22 @@ To disable this feature, set the `float` property to `false`.
 
 ## Date Modified
 By default, daux.io will display the last modified time as reported by the system underneath the title for each document. 
-To disable this, change the option in your config.json to false.
+To disable this, change the option in your config.json to `false`.
 
 ```json
 {
   "html": { "date_modified": false }
+}
+```
+
+If you want to use the last modified time you can set the [format](http://php.net/manual/function.date.php) with the `date_modified_format` option.
+
+```json
+{
+  "html": {
+    "date_modified": true,
+    "date_modified_format": "l, F j, Y g:i A"
+  }
 }
 ```
 

--- a/docs/config.json
+++ b/docs/config.json
@@ -16,6 +16,7 @@
         "breadcrumb_separator": "Chevrons",
         "toggle_code": true,
         "date_modified": true,
+        "date_modified_format": "l, F j, Y g:i A",
         "float": true,
         "inherit_index": true,
 

--- a/global.json
+++ b/global.json
@@ -28,6 +28,7 @@
 		"breadcrumb_separator": "Chevrons",
         "toggle_code": true,
         "date_modified": false,
+        "date_modified_format": "l, F j, Y g:i A",
         "float": false,
         "auto_landing": true,
         "search": true,

--- a/templates/content.php
+++ b/templates/content.php
@@ -5,7 +5,8 @@
         <h1><?= $page['breadcrumbs'] ? $this->get_breadcrumb_title($page, $base_page) : $page['title'] ?></h1>
         <?php if ($params['html']['date_modified']) { ?>
         <span style="float: left; font-size: 10px; color: gray;">
-            <?= date("l, F j, Y g:i A", $page['modified_time']); ?>
+            <?php $date_format = isset($params['html']['date_modified_format']) ? $params['html']['date_modified_format'] : 'l, F j, Y g:i A'; ?>
+            <?= date($date_format, $page['modified_time']); ?>
         </span>
         <?php } ?>
         <?php


### PR DESCRIPTION
This patch adds  a `date_modified_format` option to HTML export.

With this option you can change the  date format from the modified time in the HTML export.