### PR TITLE
Use CSS classes for "Modified Date" and "Edit On" in page header

### DIFF
--- a/global.json
+++ b/global.json
@@ -44,6 +44,19 @@
             "Edit_on": "Editer sur :name:",
             "View_on_github": "Voir sur GitHub",
             "View_documentation": "Voir la Documentation"
+        },
+        "de": {
+            "CodeBlocks_title": "Code-Blöcke",
+            "CodeBlocks_hide": "Aus",
+            "CodeBlocks_below": "Unterhalb",
+            "CodeBlocks_inline": "Linear",
+            "CodeBlocks_show": "Code-Blöcke anzeigen",
+            "Search_placeholder": "Suchen...",
+            "Link_previous": "Zurück",
+            "Link_next": "Weiter",
+            "Edit_on": "Bearbeiten bei :name:",
+            "View_on_github": "Bei GitHub anzeigen",
+            "View_documentation": "Dokumentation anzeigen"
         }
     },
 

--- a/templates/content.php
+++ b/templates/content.php
@@ -4,7 +4,7 @@
     <div class="Page__header">
         <h1><?= $page['breadcrumbs'] ? $this->get_breadcrumb_title($page, $base_page) : $page['title'] ?></h1>
         <?php if ($params['html']['date_modified']) { ?>
-        <span style="float: left; font-size: 10px; color: gray;">
+        <span class="ModifiedDate">
             <?php $date_format = isset($params['html']['date_modified_format']) ? $params['html']['date_modified_format'] : 'l, F j, Y g:i A'; ?>
             <?= date($date_format, $page['modified_time']); ?>
         </span>
@@ -12,7 +12,7 @@
         <?php
         $edit_on = $params->getHTML()->getEditOn();
         if ($edit_on) { ?>
-        <span style="float: right; font-size: 10px; color: gray;">
+        <span class="EditOn">
             <a href="<?= $edit_on['basepath'] ?>/<?= $page['relative_path'] ?>" target="_blank">
                 <?= str_replace(":name:", $edit_on['name'], $this->translate("Edit_on")) ?>
             </a>

--- a/themes/daux/less/_components.less
+++ b/themes/daux/less/_components.less
@@ -256,6 +256,18 @@ Components
     a {
         text-decoration: none;
     }
+
+    .ModifiedDate {
+        float: left;
+        font-size: 10px;
+        color: gray;
+    }
+
+    .EditOn {
+        float: right;
+        font-size: 10px;
+        color: gray;
+    }
 }
 
 .Links {


### PR DESCRIPTION
This patch format the "Modified Date" and "Edit On" in page header with CSS classes.

So it can changed with a theme. :)