### PR TITLE
Add `description`, `keywords` and `author` to Front Matter (fix #20)

### DIFF
--- a/docs/01_Features/Front_Matter.md
+++ b/docs/01_Features/Front_Matter.md
@@ -1,18 +1,28 @@
+---
+description: With Front Matter you can customize your pages even further.
+keywords: "Front Matter, Customize, Title, Description, Keywords, Author"
+author: Daux.io Team
+---
+
 To customize your pages even further, you can add a Front Matter to your files.
 
 Front Matter is a block you add at the top of your file and looks like this:
 
     ---
     title: Hallo Welt
+    keywords: "Hallo, Hello, Welt, World, Erde, Earth"
+    author: German Daux.io Team
     date: 12th December 1984
     ---
 
 ## Changing the title
 
-The only implemented customization right now is the override of the title.
-
 If your file is named "Hello_World_de.md" and your front matter is the one displayed above, you will get a page named "Hallo Welt"
+
+## Search Engine Optimization
+
+For a better **SEO** experience you can change the `description`, `keywords` and `author` meta tags.
 
 ## For Developers
 
-You can then access this information in each `Content` with `$content->getAttributes()`
+You can then access this information in each `Content` with `$content->getAttributes()` or with `$page['attributes']` in a template.

--- a/libs/Format/HTML/ContentPage.php
+++ b/libs/Format/HTML/ContentPage.php
@@ -90,6 +90,7 @@ class ContentPage extends \Todaymade\Daux\Format\Base\ContentPage
             'breadcrumbs' => $params['html']['breadcrumbs'],
             'prev' => $this->file->getPrevious(),
             'next' => $this->file->getNext(),
+            'attributes' => $this->file->getAttribute()
         ];
 
         if ($page['breadcrumbs']) {

--- a/templates/layout/00_layout.php
+++ b/templates/layout/00_layout.php
@@ -2,8 +2,21 @@
 <html class="no-js" lang="<?=$params['language'] ?>">
 <head>
     <title><?= $page['title']; ?> <?= ($page['title'] != $params['title'])? '- ' . $params['title'] : "" ?></title>
-    <meta name="description" content="<?= $params['tagline']; ?>">
-    <meta name="author" content="<?= $params['author']; ?>">
+<?php //SEO meta tags...
+    if (array_key_exists('description', $page['attributes'])) {
+        echo "    <meta name=\"description\" content=\"{$page['attributes']['description']}\">\n";
+    } elseif (array_key_exists('tagline', $params)) {
+        echo "    <meta name=\"description\" content=\"{$params['tagline']}\">\n";
+    }
+    if (array_key_exists('keywords', $page['attributes'])) {
+        echo "    <meta name=\"keywords\" content=\"{$page['attributes']['keywords']}\">\n";
+    }
+    if (array_key_exists('author', $page['attributes'])) {
+        echo "    <meta name=\"author\" content=\"{$page['attributes']['author']}\">\n";
+    } elseif (array_key_exists('author', $params)) {
+        echo "    <meta name=\"author\" content=\"{$params['author']}\">\n";
+    }
+?>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
 


### PR DESCRIPTION
This patch adds  `description`, `keywords` and `author` to Front Matter. It will use as meta tags in the HTML page.

This should fix Issue #20