### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
         "justinwalsh/daux.io": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "~5",
+        "phpunit/phpunit": "~5.7",
         "mikey179/vfsStream": "^1.6"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "9e938ead59846576154220013f069892",
+    "content-hash": "efcf7514a9c5a5385f89f05c9bec4e6b",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/tests/ContentTypes/Markdown/LinkRendererTest.php
+++ b/tests/ContentTypes/Markdown/LinkRendererTest.php
@@ -1,4 +1,5 @@
-<?php namespace Todaymade\Daux\ContentTypes\Markdown;
+<?php
+namespace Todaymade\Daux\ContentTypes\Markdown;
 
 use org\bovigo\vfs\vfsStream;
 use Todaymade\Daux\Config;
@@ -6,8 +7,9 @@ use Todaymade\Daux\Daux;
 use Todaymade\Daux\DauxHelper;
 use Todaymade\Daux\Tree\Builder;
 use Todaymade\Daux\Tree\Root;
+use PHPUnit\Framework\TestCase;
 
-class LinkRendererTest extends \PHPUnit_Framework_TestCase
+class LinkRendererTest extends TestCase
 {
     protected function getTree(Config $config)
     {

--- a/tests/DauxHelperTest.php
+++ b/tests/DauxHelperTest.php
@@ -1,6 +1,9 @@
-<?php namespace Todaymade\Daux;
+<?php
+namespace Todaymade\Daux;
 
-class DauxHelperTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class DauxHelperTest extends TestCase
 {
     public function providerGetFilenames()
     {

--- a/tests/Format/Confluence/ApiTest.php
+++ b/tests/Format/Confluence/ApiTest.php
@@ -1,7 +1,9 @@
 <?php
 namespace Todaymade\Daux\Format\Confluence;
 
-class ApiTest extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+class ApiTest extends TestCase
 {
     // this test supports upgrade Guzzle to version 6
     public function testClientOptions()

--- a/tests/Format/HTML/ConfigTest.php
+++ b/tests/Format/HTML/ConfigTest.php
@@ -1,8 +1,10 @@
-<?php namespace Todaymade\Daux\Format\HTML;
+<?php
+namespace Todaymade\Daux\Format\HTML;
 
 use Todaymade\Daux\Config as MainConfig;
+use PHPUnit\Framework\TestCase;
 
-class ConfigTest extends \PHPUnit_Framework_TestCase
+class ConfigTest extends TestCase
 {
     function testHTMLConfigCreation() {
         $config = new MainConfig(['html' => ['edit_on' => 'test']]);

--- a/tests/Format/HTML/TableOfContentsTest.php
+++ b/tests/Format/HTML/TableOfContentsTest.php
@@ -1,9 +1,11 @@
-<?php namespace Todaymade\Daux\Format\HTML;
+<?php
+namespace Todaymade\Daux\Format\HTML;
 
 use Todaymade\Daux\Config as MainConfig;
 use \Todaymade\Daux\Format\HTML\ContentTypes\Markdown\CommonMarkConverter;
+use PHPUnit\Framework\TestCase;
 
-class TableOfContentsTest extends \PHPUnit_Framework_TestCase
+class TableOfContentsTest extends TestCase
 {
     function testNoTOCByDefault() {
         $converter = new CommonMarkConverter(['daux' => new MainConfig]);
@@ -87,5 +89,3 @@ EXPECTED;
         $this->assertEquals($expected, $converter->convertToHtml($source));
     }
 }
-
-

--- a/tests/Tree/BuilderIntegrationTest.php
+++ b/tests/Tree/BuilderIntegrationTest.php
@@ -1,11 +1,13 @@
-<?php namespace Todaymade\Daux\Tree;
+<?php
+namespace Todaymade\Daux\Tree;
 
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use Todaymade\Daux\Config;
 use Todaymade\Daux\Daux;
+use PHPUnit\Framework\TestCase;
 
-class BuilderIntegrationTest extends \PHPUnit_Framework_TestCase
+class BuilderIntegrationTest extends TestCase
 {
     /**
      * @var vfsStreamDirectory

--- a/tests/Tree/BuilderTest.php
+++ b/tests/Tree/BuilderTest.php
@@ -1,9 +1,11 @@
-<?php namespace Todaymade\Daux\Tree;
+<?php
+namespace Todaymade\Daux\Tree;
 
 use Todaymade\Daux\Config;
 use Todaymade\Daux\Daux;
+use PHPUnit\Framework\TestCase;
 
-class BuilderTest extends \PHPUnit_Framework_TestCase
+class BuilderTest extends TestCase
 {
     public function providerRemoveSorting()
     {

--- a/tests/Tree/ContentTest.php
+++ b/tests/Tree/ContentTest.php
@@ -1,8 +1,10 @@
-<?php namespace Todaymade\Daux\Tree;
+<?php
+namespace Todaymade\Daux\Tree;
 
 use Todaymade\Daux\Config;
+use PHPUnit\Framework\TestCase;
 
-class ContentTest extends \PHPUnit_Framework_TestCase
+class ContentTest extends TestCase
 {
     protected function createContent($content)
     {

--- a/tests/Tree/DirectoryTest.php
+++ b/tests/Tree/DirectoryTest.php
@@ -1,8 +1,10 @@
-<?php namespace Todaymade\Daux\Tree;
+<?php
+namespace Todaymade\Daux\Tree;
 
 use Todaymade\Daux\Config;
+use PHPUnit\Framework\TestCase;
 
-class DirectoryTest extends \PHPUnit_Framework_TestCase
+class DirectoryTest extends TestCase
 {
     public function providerSort()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^5.7`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-5.7.md#570---2016-12-02), that support this namespace.