### PR TITLE
Translate days and months in modified date

### DIFF
--- a/global.json
+++ b/global.json
@@ -30,7 +30,11 @@
             "Link_next": "Next",
             "Edit_on": "Edit on :name:",
             "View_on_github": "View On GitHub",
-            "View_documentation": "View Documentation"
+            "View_documentation": "View Documentation",
+            "Days": [ "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"],
+            "Days_abbr": [ "Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"],
+            "Months": [ "January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December" ],
+            "Months_abbr": [ "Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec" ]
         },
         "fr": {
             "CodeBlocks_title": "Afficher le code",
@@ -56,7 +60,11 @@
             "Link_next": "Weiter",
             "Edit_on": "Bearbeiten bei :name:",
             "View_on_github": "Bei GitHub anzeigen",
-            "View_documentation": "Dokumentation anzeigen"
+            "View_documentation": "Dokumentation anzeigen",
+            "Days": [ "Montag", "Dienstag", "Mittwoch", "Donnerstag", "Freitag", "Samstag", "Sonntag"],
+            "Days_abbr": [ "Mo", "Di", "Mi", "Do", "Fr", "Sa", "So"],
+            "Months": [ "Januar", "Februar", "März", "April", "Mai", "Juni", "Juli", "August", "September", "Oktober", "November", "Dezember" ],
+            "Months_abbr": [ "Jan", "Feb", "Mär", "Apr", "Mai", "Jun", "Jul", "Aug", "Sep", "Okt", "Nov", "Dez" ]
         }
     },
 

--- a/libs/Format/HTML/Template.php
+++ b/libs/Format/HTML/Template.php
@@ -77,6 +77,28 @@ class Template
             return "Unknown key $key";
         });
 
+        $this->engine->registerFunction('translate_date', function ($date) {
+            $language = $this->params['language'];
+
+            if (array_key_exists('Days', $this->params['strings'][$language])) {
+                $date = str_replace($this->params['strings']['en']['Days'], $this->params['strings'][$language]['Days'], $date);
+            }
+
+            if (array_key_exists('Days_abbr', $this->params['strings'][$language])) {
+                $date = str_replace($this->params['strings']['en']['Days_abbr'], $this->params['strings'][$language]['Days_abbr'], $date);
+            }
+
+            if (array_key_exists('Months', $this->params['strings'][$language])) {
+                $date = str_replace($this->params['strings']['en']['Months'], $this->params['strings'][$language]['Months'], $date);
+            }
+
+            if (array_key_exists('Months_abbr', $this->params['strings'][$language])) {
+                $date = str_replace($this->params['strings']['en']['Months_abbr'], $this->params['strings'][$language]['Months_abbr'], $date);
+            }
+
+            return $date;
+        });
+
         $this->engine->registerFunction('get_breadcrumb_title', function ($page, $base_page) {
             $title = '';
             $breadcrumb_trail = $page['breadcrumb_trail'];

--- a/templates/content.php
+++ b/templates/content.php
@@ -6,7 +6,7 @@
         <?php if ($params['html']['date_modified']) { ?>
         <span class="ModifiedDate">
             <?php $date_format = isset($params['html']['date_modified_format']) ? $params['html']['date_modified_format'] : 'l, F j, Y g:i A'; ?>
-            <?= date($date_format, $page['modified_time']); ?>
+            <?= $this->translate_date(date($date_format, $page['modified_time'])); ?>
         </span>
         <?php } ?>
         <?php


### PR DESCRIPTION
This patch make it possible to translate the days and months names in modified date.

The correct way would be to use `setlocale()` to translate the date, but it is really tricky to find the correct locale on a system. The way to replace just the names works on any system and should be enough for most users. ;)