### PR TITLE
Allow Daux to work from sub-directories

### DIFF
--- a/libs/Server/Server.php
+++ b/libs/Server/Server.php
@@ -142,7 +142,7 @@ class Server
     {
         $this->params = $this->getParams();
 
-        $request = substr($this->request->getRequestUri(), 1);
+        $request = substr($this->request->getRequestUri(), strlen($this->request->getBaseUrl()) + 1);
 
         if (substr($request, 0, 7) == 'themes/') {
             return $this->serveTheme(substr($request, 6));


### PR DESCRIPTION
If you try to host Daux from any directory other than the root of a website (like mysite.com/docs, for example), it just gives an error that the page can't be found. This commit will make Daux remove the base directory from the request when handling it, which should make it work properly in sub-directories.