### PR TITLE
Changed Server.php to be able to run on symfony 4.0+

### DIFF
--- a/libs/Console/Serve.php
+++ b/libs/Console/Serve.php
@@ -42,8 +42,8 @@ class Serve extends DauxCommand
         putenv('DAUX_CONFIGURATION=' . $daux->getParams()->getConfigurationOverrideFile());
         putenv('DAUX_EXTENSION=' . DAUX_EXTENSION);
 
-        $base = ProcessUtils::escapeArgument(__DIR__ . '/../../');
-        $binary = ProcessUtils::escapeArgument((new PhpExecutableFinder)->find(false));
+        $base = escapeshellarg(__DIR__ . '/../../');
+        $binary = escapeshellarg((new PhpExecutableFinder)->find(false));
 
         echo "Daux development server started on http://{$host}:{$port}/\n";
 


### PR DESCRIPTION
The goal of this MR is to be able to run daux in `serve` mode.

It's not working anymore since Symfony 4.0 and this fixes the issue by using the `escapeshellarg` method from PHP instead of the one that was removed from Symfony