### PR TITLE
Fix TOC template rendering

### DIFF
--- a/libs/Format/HTML/ContentTypes/Markdown/TOC/Renderer.php
+++ b/libs/Format/HTML/ContentTypes/Markdown/TOC/Renderer.php
@@ -17,6 +17,6 @@ class Renderer implements BlockRendererInterface
         $content = $htmlRenderer->renderBlocks($block->children());
         return $this->config->templateRenderer
             ->getEngine($this->config)
-            ->render('partials/table_of_contents', ['content' => $content]);
+            ->render('theme::partials/table_of_contents', ['content' => $content]);
     }
 }


### PR DESCRIPTION
TOC renderer only takes default template into account. 
Adding `theme::` fix it, it will use `theme` folder if there is one.