### PR TITLE
Translate framework based on shown content

### DIFF
--- a/global.json
+++ b/global.json
@@ -76,6 +76,20 @@
             "View_on_github": "Bei GitHub anzeigen",
             "View_documentation": "Dokumentation anzeigen",
             "Table_of_contents": "Inhaltsverzeichnis"
+        },
+        "it": {
+            "CodeBlocks_title": "Blocchi di codice",
+            "CodeBlocks_hide": "No",
+            "CodeBlocks_below": "Sotto",
+            "CodeBlocks_inline": "In linea",
+            "CodeBlocks_show": "Mostra blocchi di codice",
+            "Search_placeholder": "Cerca...",
+            "Link_previous": "Pagina precedente",
+            "Link_next": "Pagina successiva",
+            "Edit_on": "Modifica su :name:",
+            "View_on_github": "Guarda su GitHub",
+            "View_documentation": "Leggi la documentazione",
+            "Table_of_contents": "Contenuti"
         }
     },
 

--- a/global.json
+++ b/global.json
@@ -76,20 +76,6 @@
             "View_on_github": "Bei GitHub anzeigen",
             "View_documentation": "Dokumentation anzeigen",
             "Table_of_contents": "Inhaltsverzeichnis"
-        },
-        "it": {
-            "CodeBlocks_title": "Blocchi di codice",
-            "CodeBlocks_hide": "No",
-            "CodeBlocks_below": "Sotto",
-            "CodeBlocks_inline": "In linea",
-            "CodeBlocks_show": "Mostra blocchi di codice",
-            "Search_placeholder": "Cerca...",
-            "Link_previous": "Pagina precedente",
-            "Link_next": "Pagina successiva",
-            "Edit_on": "Modifica su :name:",
-            "View_on_github": "Guarda su GitHub",
-            "View_documentation": "Leggi la documentazione",
-            "Table_of_contents": "Contenuti"
         }
     },
 

--- a/libs/Format/HTML/Template.php
+++ b/libs/Format/HTML/Template.php
@@ -1,4 +1,6 @@
-<?php namespace Todaymade\Daux\Format\HTML;
+<?php
+
+namespace Todaymade\Daux\Format\HTML;
 
 use League\Plates\Engine;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -84,8 +86,17 @@ class Template
         $engine->registerFunction('translate', function ($key) {
             $language = $this->params['language'];
 
-            if (array_key_exists($key, $this->params['strings'][$language])) {
-                return $this->params['strings'][$language][$key];
+            if (isset($this->engine->getData('page')['page'])) {
+                $page = $this->engine->getData('page');
+                if (is_array($page['page'])) {
+                    $language = $page['page']['language'];
+                }
+            }
+
+            if (array_key_exists($language, $this->params['strings'])) {
+                if (array_key_exists($key, $this->params['strings'][$language])) {
+                    return $this->params['strings'][$language][$key];
+                }
             }
 
             if (array_key_exists($key, $this->params['strings']['en'])) {

--- a/tests/Format/HTML/TableOfContentsTest.php
+++ b/tests/Format/HTML/TableOfContentsTest.php
@@ -1,5 +1,6 @@
 <?php
-namespace Todaymade\Daux\Format\HTML;
+
+namespace Todaymade\Daux\Format\HTML\Test;
 
 use Todaymade\Daux\Config as MainConfig;
 use \Todaymade\Daux\Format\HTML\ContentTypes\Markdown\CommonMarkConverter;

--- a/tests/Format/Template/TranslateTest.php
+++ b/tests/Format/Template/TranslateTest.php
@@ -1,0 +1,100 @@
+<?php
+namespace Todaymade\Daux\Format\Template;
+
+use org\bovigo\vfs\vfsStream;
+use Todaymade\Daux\Config;
+use Todaymade\Daux\Daux;
+use Todaymade\Daux\DauxHelper;
+use Todaymade\Daux\Format\HTML\Template;
+use Todaymade\Daux\Tree\Builder;
+use Todaymade\Daux\Tree\Entry;
+use Todaymade\Daux\Tree\Root;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Class TranslateTest
+ *
+ * @package Todaymade\Daux\Format\Template
+ */
+class TranslateTest extends TestCase
+{
+    protected function getTree(Config $config)
+    {
+        $structure = [
+            'en' => [
+                'Page.md' => 'some text content',
+            ],
+            'it' => [
+                'Page.md' => 'another page',
+            ],
+        ];
+        $root = vfsStream::setup('root', null, $structure);
+
+        $config->setDocumentationDirectory($root->url());
+        $config['valid_content_extensions'] = ['md'];
+        $config['mode'] = Daux::STATIC_MODE;
+        $config['index_key'] = 'index.html';
+
+        $tree = new Root($config);
+        Builder::build($tree, []);
+
+        return $tree;
+    }
+
+    public function translateDataProvider()
+    {
+        return [
+            ['Previous', 'en'],
+            ['Pagina precedente', 'it'],
+        ];
+    }
+
+    /**
+     * @dataProvider translateDataProvider
+     *
+     * @param $expectedTranslation
+     * @param $language
+     */
+    public function testTranslate($expectedTranslation, $language)
+    {
+        $current = $language . '/Page.html';
+        $entry = $this->prophesize(Entry::class);
+
+        $config = new Config();
+        $config['tree']      = $this->getTree($config);
+        $config['title']     = '';
+        $config['index']     = $entry->reveal();
+        $config['language']  = $language;
+        $config['base_url']  = '';
+        $config['base_page'] = '';
+        $config['templates'] = '';
+        $config['page']['language'] = $language;
+
+        $config['html'] = [
+            'search'           => '',
+            'float'            => false,
+            'toggle_code'      => false,
+            'piwik_analytics'  => '',
+            'google_analytics' => '',
+        ];
+        $config['theme'] = [
+            'js'        => [''],
+            'css'       => [''],
+            'fonts'     => [''],
+            'favicon'   => '',
+            'templates' => 'name',
+        ];
+        $config['strings'] = [
+            'en' => ['Link_previous' => 'Previous',],
+            'it' => ['Link_previous' => 'Pagina precedente',],
+        ];
+
+
+        $config->setCurrentPage(DauxHelper::getFile($config['tree'], $current));
+
+        $template = new Template($config);
+        $value = $template->getEngine($config)->getFunction('translate')->call(null, ['Link_previous']);
+
+        $this->assertEquals($expectedTranslation, $value);
+    }
+}


### PR DESCRIPTION
I noticed the the `language` variable on the configuration file translates the whole application, regardless of the language of the page a user is reading.

Let me give an example.

Given the config language variable is set to 'en'
When a user opens the page `en/Getting_Started.md`
Then he sees a button with the "Next" caption
When a user opens the page `fr/Commencer.md`
Then he sees a button with the "Next" caption

So, if a french user is reading a documentation that is written in french, he sees buttons (and search labels, and other labels) in english.

My PR let the user reading the french page to see the french "Suivant" caption on the next page button, as well as any other label on the framework :)



