### PR TITLE
Global language get ignored

### DIFF
--- a/libs/Format/HTML/Template.php
+++ b/libs/Format/HTML/Template.php
@@ -88,7 +88,7 @@ class Template
 
             if (isset($this->engine->getData('page')['page'])) {
                 $page = $this->engine->getData('page');
-                if (is_array($page['page'])) {
+                if (!empty($page['page']['language'])) {
                     $language = $page['page']['language'];
                 }
             }


### PR DESCRIPTION
If a page has no language configured, the global language setting get ignored.