### PR TITLE
Fix directories with unicode characters not being supported

### DIFF
--- a/libs/Tree/Builder.php
+++ b/libs/Tree/Builder.php
@@ -75,7 +75,7 @@ class Builder
             }
 
             if ($file->isDir()) {
-                $title = static::removeSortingInformations($file->getFilename());
+                $title = DauxHelper::slug(static::removeSortingInformations($file->getFilename()));
                 $new = new Directory($node, $title, $file);
                 $new->setName(static::getName($file->getPathName()));
                 $new->setTitle(str_replace('_', ' ', static::removeSortingInformations($new->getName())));


### PR DESCRIPTION
Unicode characters work fine in page files, but if you use them in directory names then Daux will fail to load that directory and any pages within them because they are not sanitized properly. This PR changes directory names to be slugified just like pages.