### PR TITLE
Catch localStorage access failures

### DIFF
--- a/themes/daux/js/daux.js
+++ b/themes/daux/js/daux.js
@@ -22,7 +22,11 @@ $(function () {
     }
 
     function setCodeBlockStyle(codeBlockState) {
-        localStorage.setItem("codeBlockState", codeBlockState);
+        try {
+            localStorage.setItem("codeBlockState", codeBlockState);
+        } catch (e) {
+            // local storage operations can fail with the file:// protocol
+        }
 
         toggleCodeBlockBtns.removeClass("Button--active");
 
@@ -60,7 +64,12 @@ $(function () {
     toggleCodeBlockBtnFloat.click(function() { setCodeBlockStyle(2); });
 
     var floating = $(document.body).hasClass("with-float");
-    var codeBlockState = localStorage.getItem("codeBlockState");
+    try {
+        var codeBlockState = localStorage.getItem("codeBlockState");
+    } catch (e) {
+        // local storage operations can fail with the file:// protocol
+        var codeBlockState = false;
+    }
 
     if (!codeBlockState) {
         codeBlockState = floating? 2 : 1;
@@ -95,4 +104,3 @@ $(function () {
         $('.Collapsible__content').slideToggle();
     });
 });
-


### PR DESCRIPTION
When reading static documentation from the filesystem i.e. via the `file://` protocol accesses to `window.localStorage` fail, which in turn cause script execution to stop prematurely.

This has the fairly serious side effect of preventing non-indexed section expansion on any pages which have code blocks.

This patch simply wraps access to `window.localStorage` in a try-block so that execution may continue.