### PR TITLE
docs: fix docker usage on access localhost:8085

### DIFF
--- a/docs/00_Getting_Started.md
+++ b/docs/00_Getting_Started.md
@@ -76,7 +76,7 @@ If the command isn't found, ensure your `$PATH` contains `~/.composer/vendor/bin
 Or if you wish to use Docker, the start of the command will be :
 
 ```bash
-docker run --rm -it -w /build -v "$PWD":/build daux/daux.io daux
+docker run --rm -it --network="host" -w /build -v "$PWD":/build daux/daux.io daux
 ```
 
 Any parameter valid in the PHP version is valid in the Docker version


### PR DESCRIPTION
We can't access http://localhost:8085 without setting `--network="host"`.

Add this to fix docker usage for `daux serve`.

see:
https://docs.docker.com/network/host/
