### PR TITLE
fix Search-Form Box overflowing into title container on Mobile devices.

### DIFF
--- a/src/css/theme_daux/_homepage.scss
+++ b/src/css/theme_daux/_homepage.scss
@@ -36,7 +36,6 @@ Homepage
     border-radius: 0;
     border: none;
     color: var(--homepage-hero-color);
-    overflow: hidden;
     padding-bottom: 0;
     margin-bottom: 0;
 


### PR DESCRIPTION
On mobile devices (with a screen width lower than 382 pixels) the Search form overflows from the navbar into the Homepage div. Which causes a box with the --body-background color to appear and make the Content inside said div unreadable
![image](https://github.com/dauxio/daux.io/assets/36165088/4b5d8998-6a04-44cb-86a3-180a01aeff8c)
For some reason removing the overflow: hidden option hides that box.