### PR TITLE
Authorize configuration of CommonMarkConverter (permalink, toc)

### DIFF
--- a/libs/Format/HTML/ContentTypes/Markdown/CommonMarkConverter.php
+++ b/libs/Format/HTML/ContentTypes/Markdown/CommonMarkConverter.php
@@ -12,18 +12,18 @@ class CommonMarkConverter extends \Todaymade\Daux\ContentTypes\Markdown\CommonMa
 {
     public function __construct($config)
     {
-        $config['heading_permalink'] = [
+        $config['heading_permalink'] = array_merge([
             'html_class' => 'Permalink',
             'symbol' => '#',
             'fragment_prefix' => '',
             'id_prefix' => '',
-        ];
+        ], $config['daux']['heading_permalink'] ?? []);
 
-        $config['table_of_contents'] = [
+        $config['table_of_contents'] = array_merge([
             'html_class' => 'TableOfContents',
             'position' => 'placeholder',
             'placeholder' => '[TOC]',
-        ];
+        ], $config['daux']['table_of_contents'] ?? []);
 
         parent::__construct($config);
     }

--- a/tests/Format/HTML/TableOfContentsTest.php
+++ b/tests/Format/HTML/TableOfContentsTest.php
@@ -37,6 +37,24 @@ class TableOfContentsTest extends TestCase
         $this->assertEquals("<h1><a id=\"test\" href=\"#test\" class=\"Permalink\" aria-hidden=\"true\" title=\"Permalink\">#</a>Test</h1>\n", $converter->convert('# Test')->getContent());
     }
 
+    public function testHeadingPermalinkSymbolOverride()
+    {
+        $config = $this->getConfig();
+        $config['daux']['heading_permalink'] = ['symbol' => ''];
+        $converter = new CommonMarkConverter($config);
+
+        $this->assertEquals("<h1><a id=\"test\" href=\"#test\" class=\"Permalink\" aria-hidden=\"true\" title=\"Permalink\"></a>Test</h1>\n", $converter->convert('# Test')->getContent());
+    }
+
+    public function testHeadingPermalinkCustomSymbol()
+    {
+        $config = $this->getConfig();
+        $config['daux']['heading_permalink'] = ['symbol' => '¶'];
+        $converter = new CommonMarkConverter($config);
+
+        $this->assertEquals("<h1><a id=\"test\" href=\"#test\" class=\"Permalink\" aria-hidden=\"true\" title=\"Permalink\">¶</a>Test</h1>\n", $converter->convert('# Test')->getContent());
+    }
+
     public function testShouldAddTOCWhenAutoTOCisOn()
     {
         $config = $this->getConfig();


### PR DESCRIPTION
**Summary**

- Makes the heading_permalink and table_of_contents settings in CommonMarkConverter configurable via the daux config, instead of being hardcoded                                                                 
- Default values are preserved — user-provided config under daux.heading_permalink and daux.table_of_contents is merged on top of the defaults using array_merge
- Adds tests verifying that the permalink symbol can be overridden (including to an empty string or a custom character like ¶)                                                                                   