### PR TITLE
Fall back to the shipped templates instead of failing

### DIFF
--- a/docs/10_For_Developers/Creating_a_Theme.md
+++ b/docs/10_For_Developers/Creating_a_Theme.md
@@ -91,6 +91,14 @@ You can create a folder named `templates` in your theme, copy-paste the original
 
 You can even do it one template at a time if you wish to do only small changes.
 
+Templates are looked up in this order, and the first match wins :
+
+1.  `templates` in your theme
+2.  the directory set in the `templates` option of your documentation's `config.json`, if you set one
+3.  the templates shipped with Daux.io
+
+A template that isn't in one of these directories is taken from the next one, so you never have to copy a template you don't intend to change.
+
 By default, we have the following templates :
 
 -   `content.php`: The content page.

--- a/libs/ConfigBuilder.php
+++ b/libs/ConfigBuilder.php
@@ -239,7 +239,7 @@ class ConfigBuilder
             'valid_content_extensions' => ['md', 'markdown'],
 
             // Paths and tree
-            'templates' => 'templates',
+            'templates' => $this->config->getLocalBase() . DIRECTORY_SEPARATOR . 'templates',
 
             'base_url' => '',
         ]);

--- a/libs/Format/HTML/Template.php
+++ b/libs/Format/HTML/Template.php
@@ -25,23 +25,26 @@ class Template
             return $this->engine;
         }
 
-        $base = $config->getTemplates();
-        $theme = $config->getTheme()->getTemplates();
+        // The templates shipped with Daux, they are always the last resort
+        $builtin = realpath(__DIR__ . '/../../../templates');
 
-        // Use internal templates if no templates
-        // dir exists in the working directory
-        if (!is_dir($base)) {
-            $base = __DIR__ . '/../../../templates';
+        // From the most specific to the most generic, a template that
+        // can't be found in one directory is looked up in the next one
+        $directories = [];
+        foreach ([$config->getTheme()->getTemplates(), $config->getTemplates(), $builtin] as $directory) {
+            if ($directory && is_dir($directory) && !in_array($directory, $directories, true)) {
+                $directories[] = $directory;
+            }
         }
 
         // Create new Plates instance
-        $this->engine = new Engine($base);
-        if (!is_dir($theme)) {
-            $theme = $base;
-        }
-        $this->engine->addFolder('theme', $theme, true);
+        // The directory and the 'theme' folder are only there to satisfy Plates,
+        // the lookup itself is entirely done by our resolver
+        $this->engine = new Engine($builtin);
+        $this->engine->addFolder('theme', $builtin, true);
+        $this->engine->setResolveTemplatePath(new TemplateResolver($directories));
 
-        Daux::writeln("Starting Template engine with basedir '{$base}' and theme folder '{$theme}'.", OutputInterface::VERBOSITY_VERBOSE);
+        Daux::writeln("Starting Template engine, looking up templates in '" . implode("', '", $directories) . "'.", OutputInterface::VERBOSITY_VERBOSE);
 
         $this->registerFunctions($this->engine);
 

--- a/libs/Format/HTML/TemplateResolver.php
+++ b/libs/Format/HTML/TemplateResolver.php
@@ -1,0 +1,42 @@
+<?php
+namespace Todaymade\Daux\Format\HTML;
+
+use League\Plates\Exception\TemplateNotFound;
+use League\Plates\Template\Name;
+use League\Plates\Template\ResolveTemplatePath;
+
+/**
+ * Resolves a template by walking a list of directories in order, from the most
+ * specific one (the theme) down to the templates shipped with Daux.
+ *
+ * This is what allows a theme to override only the templates it cares about,
+ * the missing ones are taken from the directory below in the list.
+ */
+class TemplateResolver implements ResolveTemplatePath
+{
+    /**
+     * @param string[] $directories ordered list of existing directories to search
+     */
+    public function __construct(private readonly array $directories) {}
+
+    public function __invoke(Name $name): string
+    {
+        $searched = [];
+
+        foreach ($this->directories as $directory) {
+            $path = $directory . DIRECTORY_SEPARATOR . $name->getFile();
+
+            if (is_file($path)) {
+                return $path;
+            }
+
+            $searched[] = $path;
+        }
+
+        throw new TemplateNotFound(
+            $name->getName(),
+            $searched,
+            'The template "' . $name->getName() . '" could not be found in any of these locations: ' . implode(', ', $searched)
+        );
+    }
+}

--- a/tests/Format/HTML/TemplateOverrideTest.php
+++ b/tests/Format/HTML/TemplateOverrideTest.php
@@ -1,0 +1,74 @@
+<?php
+namespace Todaymade\Daux\Format\HTML;
+
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Console\Output\NullOutput;
+use Todaymade\Daux\ConfigBuilder;
+use Todaymade\Daux\Daux;
+use Todaymade\Daux\DauxHelper;
+
+class TemplateOverrideTest extends TestCase
+{
+    /**
+     * An override directory only has to contain the templates it wants to
+     * change, the other ones are taken from the templates shipped with Daux.
+     *
+     * @see https://github.com/dauxio/daux.io/issues/329
+     */
+    public function testIncompleteOverrideDirectoryFallsBackToTheShippedTemplates()
+    {
+        $daux = $this->getDaux(['templates' => 'vfs://root/templates']);
+        $generator = new Generator($daux);
+
+        $config = $daux->getConfig();
+        DauxHelper::rebaseConfiguration($config, '');
+
+        $daux->tree->setActiveNode($daux->tree['index.html']);
+        $content = $generator->generateOne($daux->tree['index.html'], $config)->getContent();
+
+        // 'home.php' is not in the override directory, the shipped one is used
+        $this->assertStringContainsString('Homepage, welcome!', $content);
+        $this->assertStringNotContainsString('OVERRIDDEN CONTENT', $content);
+    }
+
+    public function testOverrideDirectoryTakesPrecedenceOverTheShippedTemplates()
+    {
+        $daux = $this->getDaux(['templates' => 'vfs://root/templates']);
+        $generator = new Generator($daux);
+
+        $config = $daux->getConfig();
+        DauxHelper::rebaseConfiguration($config, '');
+
+        $daux->tree->setActiveNode($daux->tree['Content']['Page.html']);
+        $content = $generator->generateOne($daux->tree['Content']['Page.html'], $config)->getContent();
+
+        $this->assertStringContainsString('OVERRIDDEN CONTENT', $content);
+    }
+
+    protected function getDaux($moreConfig = [])
+    {
+        vfsStream::setup('root', null, [
+            'docs' => [
+                'index.md' => 'Homepage, welcome!',
+                'Content' => [
+                    'Page.md' => 'some text content',
+                ],
+            ],
+            'templates' => [
+                'content.php' => 'OVERRIDDEN CONTENT',
+            ],
+        ]);
+
+        $config = ConfigBuilder::withMode()
+            ->withDocumentationDirectory('vfs://root/docs')
+            ->withValidContentExtensions(['md'])
+            ->with($moreConfig)
+            ->build();
+
+        $daux = new Daux($config, new NullOutput());
+        $daux->generateTree();
+
+        return $daux;
+    }
+}

--- a/tests/Format/HTML/TemplateResolverTest.php
+++ b/tests/Format/HTML/TemplateResolverTest.php
@@ -1,0 +1,86 @@
+<?php
+namespace Todaymade\Daux\Format\HTML;
+
+use League\Plates\Engine;
+use League\Plates\Exception\TemplateNotFound;
+use League\Plates\Template\Name;
+use org\bovigo\vfs\vfsStream;
+use PHPUnit\Framework\TestCase;
+
+class TemplateResolverTest extends TestCase
+{
+    public function testTakesTheFirstDirectoryContainingTheTemplate()
+    {
+        $root = $this->getRoot();
+        $resolver = new TemplateResolver([$root->url() . '/theme', $root->url() . '/builtin']);
+
+        $this->assertEquals(
+            $root->url() . '/theme/home.php',
+            $resolver($this->getName('theme::home'))
+        );
+    }
+
+    public function testFallsBackToTheNextDirectory()
+    {
+        $root = $this->getRoot();
+        $resolver = new TemplateResolver([$root->url() . '/theme', $root->url() . '/builtin']);
+
+        $this->assertEquals(
+            $root->url() . '/builtin/content.php',
+            $resolver($this->getName('theme::content'))
+        );
+    }
+
+    public function testResolvesNestedTemplates()
+    {
+        $root = $this->getRoot();
+        $resolver = new TemplateResolver([$root->url() . '/theme', $root->url() . '/builtin']);
+
+        $this->assertEquals(
+            $root->url() . '/builtin/layout/00_layout.php',
+            $resolver($this->getName('theme::layout/00_layout'))
+        );
+    }
+
+    public function testListsAllSearchedPathsWhenNothingMatches()
+    {
+        $root = $this->getRoot();
+        $resolver = new TemplateResolver([$root->url() . '/theme', $root->url() . '/builtin']);
+
+        try {
+            $resolver($this->getName('theme::missing'));
+            $this->fail('Expected a TemplateNotFound exception');
+        } catch (TemplateNotFound $e) {
+            $this->assertEquals(
+                [$root->url() . '/theme/missing.php', $root->url() . '/builtin/missing.php'],
+                $e->paths()
+            );
+            $this->assertStringContainsString($root->url() . '/theme/missing.php', $e->getMessage());
+            $this->assertStringContainsString($root->url() . '/builtin/missing.php', $e->getMessage());
+        }
+    }
+
+    private function getRoot()
+    {
+        return vfsStream::setup('root', null, [
+            'theme' => [
+                'home.php' => 'theme home',
+            ],
+            'builtin' => [
+                'home.php' => 'builtin home',
+                'content.php' => 'builtin content',
+                'layout' => [
+                    '00_layout.php' => 'builtin layout',
+                ],
+            ],
+        ]);
+    }
+
+    private function getName($name)
+    {
+        $engine = new Engine(vfsStream::url('root'));
+        $engine->addFolder('theme', vfsStream::url('root/theme'));
+
+        return new Name($engine, $name);
+    }
+}


### PR DESCRIPTION
Fixes #329

## The problem

Running `daux generate` from a repository that happens to contain an unrelated `templates/` folder fails:

```
Generating ...
- index.html                                                          [ FAIL ]
In Template.php line 155:
  The template "theme::home" could not be found at "templates/home.php".
```

Two defects combine to cause this.

**The `templates` config value was a bare relative string.** `ConfigBuilder` set `'templates' => 'templates'` and never normalized it, unlike `docs_directory` and `themes_directory` which both go through `findLocation()`. Since `local_base` is the Daux install root, the value was clearly meant to point at Daux's own `templates/` folder. Because it stayed relative, `is_dir($base)` resolved it against the **current working directory** and picked up whatever folder of that name sat in the user's repository.

**Plates only offers a single-level fallback.** `addFolder('theme', $theme, true)` falls back to the engine's default directory and nowhere else. The shipped themes have no `templates/` subfolder, so `Template::getEngine()` set `$theme = $base`, and every `theme::*` lookup landed in the hijacked folder with no escape hatch.

Worth noting that the failure above is the *lucky* outcome. If the unrelated folder happened to contain a file named `home.php` or `content.php`, Daux silently rendered it instead of the real template.

## The fix

Templates are now looked up through an ordered chain, and the first match wins:

```
theme::home ->
  1. <themes_path>/<theme>/templates/home.php
  2. <config.templates>/home.php     (only when explicitly configured)
  3. <daux>/templates/home.php       (always exists)
```

This preserves today's precedence, where the theme outranks the base directory, and adds the third level that was missing.

### `libs/Format/HTML/TemplateResolver.php` (new)

Implements `League\Plates\Template\ResolveTemplatePath`, the extension point Plates 3.6 provides for exactly this. It walks the directories in order and returns the first one holding the template. When none does, it throws `TemplateNotFound` listing **every** path it tried rather than only the last one, which makes a genuine typo far easier to diagnose:

```
The template "theme::nonexistent" could not be found in any of these locations:
/path/to/mythemes/mytheme/templates/nonexistent.php, templates/nonexistent.php,
/path/to/daux.io/templates/nonexistent.php
```

Plates ships its own `ThemeResolveTemplatePath` with a similar hierarchy, but it builds paths from the full template name, so it is incompatible with the `theme::` prefix that every template and every existing custom theme already uses.

### `libs/Format/HTML/Template.php`

`getEngine()` builds the chain, dropping entries that do not exist and de-duplicating so the default case does not list the shipped directory twice. The Plates engine directory and the `theme` folder registration are kept because `Name::setFolder()` throws when the folder is unknown and `Folder::setPath()` throws on a missing directory, but both now point at the shipped templates and the real lookup is entirely the resolver's job. The verbose log line prints the whole chain instead of a base directory and a theme folder.

A side benefit: unprefixed names such as `$this->layout('layout/00_layout')` now resolve through the same chain rather than only hitting the engine's default directory.

### `libs/ConfigBuilder.php`

The default `templates` value is now absolute, anchored on `local_base`. An unrelated folder in the working directory is never picked up.

This deliberately does **not** go through `findLocation()`: that helper checks the current directory before `local_base`, which would reintroduce the very hijack being removed. An explicitly configured relative value keeps behaving as it does today, because the resolver still tests every candidate with `is_dir()`.

### `docs/10_For_Developers/Creating_a_Theme.md`

Documents the lookup order. The page already promised that you can override "one template at a time"; this is what makes that reliable.

## Tests

- `tests/Format/HTML/TemplateResolverTest.php` covers the resolver directly: first match wins, a directory missing the file is skipped, nested names resolve, and an unresolvable name reports every searched path.
- `tests/Format/HTML/TemplateOverrideTest.php` is the end-to-end regression test. It points `templates` at a directory holding only `content.php`, then asserts the landing page still renders from the shipped `home.php` while the content page uses the override. Confirmed to fail with the old `getEngine()`, reproducing the exact error from the issue, before passing with the fix.

The existing suite is unaffected. It runs with the working directory at the repository root, where `templates/` *is* the shipped directory, and `TranslateTest` sets both candidate directories to values that are not directories, so its chain collapses to the shipped templates as before.

## Compatibility

No configuration in the repository sets the `templates` key, and the documentation only ever described overriding templates inside a theme, so the working-directory pickup was an accident rather than a feature. Anyone who does set `templates` explicitly keeps their current behaviour, and now gets fallback on top of it.

